### PR TITLE
Improve security of regexes to satisfy Rails 4.

### DIFF
--- a/lib/braintree_rails/address.rb
+++ b/lib/braintree_rails/address.rb
@@ -11,7 +11,7 @@ module BraintreeRails
     validates :first_name, :last_name, :company, :street_address, :extended_address, :locality, :region, :length => {:maximum => 255}
     validates :country_code_alpha2, :allow_blank => true, :inclusion => { :in => Braintree::Address::CountryNames.map {|country| country[1]} }
     validates :postal_code, :street_address, :presence => true
-    validates :postal_code, :format => { :with => /^[- a-z0-9]+$/i}
+    validates :postal_code, :format => { :with => /\A[- a-z0-9]+\z/i}
 
     def self.find(customer_id, id)
       new(braintree_model_class.find(customer_id, id))

--- a/lib/braintree_rails/customer.rb
+++ b/lib/braintree_rails/customer.rb
@@ -3,7 +3,7 @@ module BraintreeRails
     include Model
     define_attributes(:id, :first_name, :last_name, :email, :company, :website, :phone, :fax, :created_at, :updated_at)
 
-    validates :id, :format => {:with => /^[-_a-z0-9]*$/i}, :length => {:maximum => 36}, :exclusion => {:in => %w(all new)}
+    validates :id, :format => {:with => /\A[-_a-z0-9]*\z/i}, :length => {:maximum => 36}, :exclusion => {:in => %w(all new)}
     validates :first_name, :last_name, :company, :website, :phone, :fax, :length => {:maximum => 255}
 
     attr_reader :addresses, :credit_cards


### PR DESCRIPTION
Rails 4 was failing with this message:

"The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option?
