### PR TITLE
Add CreditCards number, cvv fields as updateable 

### DIFF
--- a/lib/braintree_rails/credit_card.rb
+++ b/lib/braintree_rails/credit_card.rb
@@ -3,7 +3,7 @@ module BraintreeRails
     include Model
     define_attributes(
       :create => [:billing_address, :cardholder_name, :customer_id, :expiration_date, :expiration_month, :expiration_year, :number, :cvv, :options, :token],
-      :update => [:billing_address, :cardholder_name, :expiration_date, :expiration_month, :expiration_year, :options],
+      :update => [:billing_address, :cardholder_name, :expiration_date, :expiration_month, :expiration_year, :options, :number, :cvv],
       :readonly => [
         :bin, :card_type, :commercial, :country_of_issuance, :created_at, :debit, :durbin_regulated, :default,
         :expired, :healthcare, :issuing_bank, :last_4, :payroll, :prepaid, :unique_number_identifier, :updated_at


### PR DESCRIPTION
Since Braintree allows for these fields to be part of a call to
update credit cards, I don't see a reason to leave them out.

This way, we're able to simulate a one-to-one Customer-CreditCard
relation without diving into complex delete-and-create logic.
