### PR TITLE
CreditCard update inconsistent when updating expiration_date

### DIFF
--- a/test/unit/braintree_rails/credit_card_test.rb
+++ b/test/unit/braintree_rails/credit_card_test.rb
@@ -319,6 +319,17 @@ describe BraintreeRails::CreditCard do
       credit_card.clear_encryped_attributes
       credit_card.number.must_be :blank?
     end
+
+    it 'should update expiration_date when required' do
+      credit_card = BraintreeRails::CreditCard.find('credit_card_id')
+      attributes = {
+        :number => '4111111111111111',
+        :cvv => '111',
+        :expiration_date => '02/2020',
+      }
+      credit_card.assign_attributes(attributes)
+      credit_card.attributes_for(:update)[:expiration_date].must_equal '02/2020'
+    end
   end
 
   describe 'class methods' do


### PR DESCRIPTION
It seems that when trying to update a `CreditCard` instance using the `expiration_date` field, leaving out `expiration_month` and `expiration_year`, i.e.

``` ruby
card.update_attributes(:number => '4111111111111111', :cvv => '666', :expiration_date => '12/2027')
```

the behaviour is inconsistent: The first time it is done on a `CreditCard` instance, the change is not registered. After that, it seems to work fine.
See testcase gist: https://gist.github.com/n0nick/5299333

In my debugging efforts, I've concluded that this is related to `lib/braintree_rails/credit_card.rb:57`:

``` ruby
attributes.delete(:expiration_date) if expiration_month.present?
```

The trouble is, `expiration_month` is always present for `CreditCard`s that were fetched from Braintree! And so, `expiration_date` gets deleted.

I've included a unit test that expects `expiration_date` to be pending an update, and thus failing for now.
I wasn't sure how to go about actually fixing the bug, since this seems like more of a design decision.
