### PR TITLE
Add :credit_card attribute to Customer model.

### DIFF
--- a/lib/braintree_rails/customer.rb
+++ b/lib/braintree_rails/customer.rb
@@ -3,8 +3,8 @@ module BraintreeRails
     include Model
 
     define_attributes(
-      :create => [:company, :custom_fields, :email, :fax, :first_name, :id, :last_name, :options, :phone, :website],
-      :update => [:company, :custom_fields, :email, :fax, :first_name, :last_name, :options, :phone, :website],
+      :create => [:company, :custom_fields, :email, :fax, :first_name, :id, :last_name, :options, :phone, :website, :credit_card],
+      :update => [:company, :custom_fields, :email, :fax, :first_name, :last_name, :options, :phone, :website, :credit_card],
       :readonly => [:created_at, :updated_at],
       :as_association => [:id, :company, :email, :fax, :first_name, :last_name, :phone, :website]
     )


### PR DESCRIPTION
This allows for creation of a credit card with a customer using nested forms.

When using the Braintree gem, a user can create a customer and credit card in one call by using nested attributes.  This extends that ability to this gem by adding the credit_card attribute to the Customer model.

Thus:

BraintreeRails::Customer.new(email: "user@example.com", credit_card: { number: "5105105105105100", expiration_date: "11/2013" })

Creates a customer with an associated card.

Also works to update, either adding a card or updating existing card.

No tests written, yet, but can be if this is something you want to merge.

Thanks for the gem!
