### PR TITLE
Fix propagation of braintree returned errors to associations for merchant accounts

### DIFF
--- a/lib/braintree_rails/address_details.rb
+++ b/lib/braintree_rails/address_details.rb
@@ -10,5 +10,9 @@ module BraintreeRails
     def self.braintree_model_name
       "merchant_account/#{name.demodulize.underscore}"
     end
+
+    def extract_errors(errors)
+      errors.for(:address) if errors
+    end
   end
 end

--- a/lib/braintree_rails/business_details.rb
+++ b/lib/braintree_rails/business_details.rb
@@ -14,7 +14,7 @@ module BraintreeRails
     end
 
     def add_errors(validation_errors)
-      address.add_errors(validation_errors) if address
+      address.add_errors(extract_errors(validation_errors)) if address
       super(validation_errors)
     end
 
@@ -24,6 +24,10 @@ module BraintreeRails
 
     def address_attributes
       address.present? ? {:address => address.attributes_for(:as_association)} : {}
+    end
+
+    def extract_errors(errors)
+      errors.for(:business)
     end
   end
 end

--- a/lib/braintree_rails/funding_details.rb
+++ b/lib/braintree_rails/funding_details.rb
@@ -13,5 +13,9 @@ module BraintreeRails
     def self.braintree_model_name
       "merchant_account/#{name.demodulize.underscore}"
     end
+
+    def extract_errors(errors)
+      errors.for(:funding)
+    end
   end
 end

--- a/lib/braintree_rails/individual_details.rb
+++ b/lib/braintree_rails/individual_details.rb
@@ -17,7 +17,7 @@ module BraintreeRails
     end
 
     def add_errors(validation_errors)
-      address.add_errors(validation_errors) if address
+      address.add_errors(extract_errors(validation_errors)) if address
       super(validation_errors)
     end
 
@@ -27,6 +27,10 @@ module BraintreeRails
 
     def address_attributes
       address.present? ? {:address => address.attributes_for(:as_association)} : {}
+    end
+
+    def extract_errors(errors)
+      errors.for(:individual)
     end
   end
 end

--- a/lib/braintree_rails/merchant_account.rb
+++ b/lib/braintree_rails/merchant_account.rb
@@ -20,11 +20,11 @@ module BraintreeRails
     after_create :reload, :if => :persisted?
 
     def add_errors(validation_errors)
-      propergate_errors_to_associations(extract_errors(validation_errors))
+      propagate_errors_to_associations(extract_errors(validation_errors))
       super(validation_errors)
     end
 
-    def propergate_errors_to_associations(validation_errors)
+    def propagate_errors_to_associations(validation_errors)
       [individual, business, funding].each do |association|
         association.add_errors(validation_errors) if association
       end

--- a/lib/braintree_rails/transaction.rb
+++ b/lib/braintree_rails/transaction.rb
@@ -64,7 +64,7 @@ module BraintreeRails
     end
 
     def add_errors(validation_errors)
-      propergate_errors_to_associations(extract_errors(validation_errors))
+      propagate_errors_to_associations(extract_errors(validation_errors))
       super(validation_errors)
     end
 
@@ -80,7 +80,7 @@ module BraintreeRails
 
     protected
 
-    def propergate_errors_to_associations(errors)
+    def propagate_errors_to_associations(errors)
       [customer, credit_card, billing, shipping].each do |association|
         association.add_errors(errors) if association
       end

--- a/spec/config/braintree_auth.yml.example
+++ b/spec/config/braintree_auth.yml.example
@@ -2,3 +2,4 @@
 merchant_id: 'merchant_id'
 public_key: 'public_key'
 private_key: 'private_key'
+default_merchant_account_id: 'default_merchant_account_id'

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -65,12 +65,12 @@ module Helper
     }
   end
 
-  def merchant_account_hash
+  def merchant_account_hash(kind = :email)
     {
       :master_merchant_account_id => BraintreeRails::Configuration.default_merchant_account_id,
       :tos_accepted => true,
       :individual => individual_details_hash,
-      :funding => funding_details_hash,
+      :funding => send("#{kind.to_s}_funding_details_hash"),
       :business => business_details_hash,
     }
   end
@@ -93,10 +93,20 @@ module Helper
     }
   end
 
-  def funding_details_hash
+  def email_funding_details_hash
     {
       :destination => Braintree::MerchantAccount::FundingDestination::Email,
       :email => "braintree-rails@exameple.com"
+    }
+  end
+
+  def bank_funding_details_hash
+    {
+      :destination => Braintree::MerchantAccount::FundingDestination::Bank,
+      :email => "braintree-rails@example.com",
+      :mobile_phone => '2015551212',
+      :account_number => '1234567890',
+      :routing_number => '071101307'
     }
   end
 

--- a/spec/unit/braintree_rails/funding_details_spec.rb
+++ b/spec/unit/braintree_rails/funding_details_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path(File.join(File.dirname(__FILE__), '../unit_spec_helper'
 describe BraintreeRails::FundingDetails do
   describe 'validations' do
     it "requries destination" do
-      funding = BraintreeRails::FundingDetails.new(funding_details_hash.merge(:destination => nil))
+      funding = BraintreeRails::FundingDetails.new(email_funding_details_hash.merge(:destination => nil))
       expect(funding).to be_invalid
       expect(funding.errors[:destination]).to eq(["can't be blank", "is not included in the list"])
     end
 
     it "cannot be trash destination" do
-      funding = BraintreeRails::FundingDetails.new(funding_details_hash.merge(:destination => "foo"))
+      funding = BraintreeRails::FundingDetails.new(email_funding_details_hash.merge(:destination => "foo"))
       expect(funding).to be_invalid
       expect(funding.errors[:destination]).to eq(["is not included in the list"])
     end
 
     it "requries email if destination is Email" do
-      funding = BraintreeRails::FundingDetails.new(funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::Email, :email => nil))
+      funding = BraintreeRails::FundingDetails.new(email_funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::Email, :email => nil))
       expect(funding).to be_invalid
       expect(funding.errors[:email]).to eq(["can't be blank"])
     end
 
     it "requries mobile_phone if destination is MobilePhone" do
-      funding = BraintreeRails::FundingDetails.new(funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::MobilePhone, :mobile_phone => nil))
+      funding = BraintreeRails::FundingDetails.new(email_funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::MobilePhone, :mobile_phone => nil))
       expect(funding).to be_invalid
       expect(funding.errors[:mobile_phone]).to eq(["can't be blank"])
     end
 
     it "requries account_number and routing_number if destination is Bank" do
-      funding = BraintreeRails::FundingDetails.new(funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::Bank, :account_number => nil, :routing_number => nil))
+      funding = BraintreeRails::FundingDetails.new(email_funding_details_hash.merge(:destination => Braintree::MerchantAccount::FundingDestination::Bank, :account_number => nil, :routing_number => nil))
       expect(funding).to be_invalid
       expect(funding.errors[:account_number]).to eq(["can't be blank"])
       expect(funding.errors[:routing_number]).to eq(["can't be blank"])

--- a/spec/unit/braintree_rails/transaction_spec.rb
+++ b/spec/unit/braintree_rails/transaction_spec.rb
@@ -218,7 +218,7 @@ describe BraintreeRails::Transaction do
       expect {transaction.submit_for_settlement!}.to raise_error(BraintreeRails::RecordInvalid)
     end
 
-    it 'should propergate api errors to associations if any' do
+    it 'should propagate api errors to associations if any' do
       customer = BraintreeRails::Customer.find('customer_id')
       credit_card = BraintreeRails::CreditCard.find('credit_card_id')
       transaction = BraintreeRails::Transaction.new(:amount => '10.00', :customer => customer, :credit_card => credit_card, :billing => address_hash, :shipping => address_hash)


### PR DESCRIPTION
Errors returned by Braintree when creating or updating merchant accounts were getting discarded rather than being applied to the associations in merchant accounts - This PR fixes the issue, adds a test, and adds testing of Bank Account type merchant account.